### PR TITLE
Fix Linux (and probably OS X) builds

### DIFF
--- a/Build/Win32/ss31client.csproj
+++ b/Build/Win32/ss31client.csproj
@@ -31,10 +31,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="MonoGame.Framework">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Framework.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.3.2.3-alpha\build\net40\AnyCPU\MonoGame.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Lidgren.Network">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\Lidgren.Network.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.Net.3.2.3-alpha\build\net40\AnyCPU\Lidgren.Network.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -60,9 +60,6 @@
       <Project>{6499D561-FF69-42A8-8AE4-1CEC2D348514}</Project>
       <Name>ss31ui</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\SS31.Client\packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="..\..\SS31.Client\Input\" />

--- a/Build/Win32/ss31common.csproj
+++ b/Build/Win32/ss31common.csproj
@@ -30,22 +30,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="MonoGame.Framework">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Lidgren.Network">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\Lidgren.Network.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml" />
     <Reference Include="YamlDotNet">
       <HintPath>packages\YamlDotNet.3.5.1\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="MonoGame.Framework">
+      <HintPath>packages\MonoGame.Binaries.3.2.3-alpha\build\net40\AnyCPU\MonoGame.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Lidgren.Network">
+      <HintPath>packages\MonoGame.Binaries.Net.3.2.3-alpha\build\net40\AnyCPU\Lidgren.Network.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\Build\Win32\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\Build\Win32\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" />
+  <Import Project="..\Build\Win32\packages\MonoGame.Binaries.3.2.3-alpha\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\Build\Win32\packages\MonoGame.Binaries.3.2.3-alpha\build\net40\MonoGame.Binaries.targets')" />
+  <Import Project="..\Build\Win32\packages\MonoGame.Binaries.Net.3.2.3-alpha\build\net40\MonoGame.Binaries.Net.targets" Condition="Exists('..\Build\Win32\packages\MonoGame.Binaries.Net.3.2.3-alpha\build\net40\MonoGame.Binaries.Net.targets')" />
   <ItemGroup>
     <Compile Include="..\..\SS31.Common\Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\SS31.Common\Service\ServiceManager.cs" />
@@ -68,13 +69,13 @@
     <Compile Include="..\..\SS31.Common\Input\IInputManager.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\SS31.Common\packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="..\..\SS31.Common\Network\" />
     <Folder Include="..\..\SS31.Common\Service\" />
     <Folder Include="..\..\SS31.Common\Utility\" />
     <Folder Include="..\..\SS31.Common\Config\" />
     <Folder Include="..\..\SS31.Common\Input\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\SS31.Common\packages.config" />
   </ItemGroup>
 </Project>

--- a/Build/Win32/ss31server.csproj
+++ b/Build/Win32/ss31server.csproj
@@ -31,10 +31,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="MonoGame.Framework">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Framework.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.3.2.3-alpha\build\net40\AnyCPU\MonoGame.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Lidgren.Network">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\Lidgren.Network.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.Net.3.2.3-alpha\build\net40\AnyCPU\Lidgren.Network.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -53,9 +53,6 @@
       <Project>{AC7A5C09-8C67-494B-B048-EAEAC5CD0E96}</Project>
       <Name>ss31common</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\SS31.Server\packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="..\..\SS31.Server\Config\" />

--- a/Build/Win32/ss31ui.csproj
+++ b/Build/Win32/ss31ui.csproj
@@ -31,13 +31,13 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="MonoGame.Framework">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Framework.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.3.2.3-alpha\build\net40\AnyCPU\MonoGame.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Lidgren.Network">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\Lidgren.Network.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.Net.3.2.3-alpha\build\net40\AnyCPU\Lidgren.Network.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK">
-      <HintPath>packages\MonoGame.Binaries.3.2.0\build\net40\OpenTK.dll</HintPath>
+      <HintPath>packages\MonoGame.Binaries.3.2.3-alpha\build\net40\OpenTK.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -47,9 +47,6 @@
       <Project>{AC7A5C09-8C67-494B-B048-EAEAC5CD0E96}</Project>
       <Name>ss31common</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\SS31.Client.UI\packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="..\..\SS31.Client.UI\Properties\" />

--- a/SS31.Client.UI/packages.config
+++ b/SS31.Client.UI/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
-</packages>

--- a/SS31.Client/packages.config
+++ b/SS31.Client/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
-</packages>

--- a/SS31.Common/packages.config
+++ b/SS31.Common/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
+  <package id="MonoGame.Binaries" version="3.2.3-alpha" targetFramework="net40" />
+  <package id="MonoGame.Binaries.Net" version="3.2.3-alpha" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="YamlDotNet" version="3.5.1" targetFramework="net40" />
 </packages>

--- a/SS31.Server/Server.cs
+++ b/SS31.Server/Server.cs
@@ -182,7 +182,7 @@ namespace SS31.Server
 		private void handleStatusChange(NetIncomingMessage msg)
 		{
 			NetConnection conn = msg.SenderConnection;
-			string sip = conn.RemoteEndpoint.Address.ToString();
+			string sip = conn.RemoteEndPoint.Address.ToString();
 			Logger.LogInfo(sip + ": STATUS CHANGE");
 
 			switch (conn.Status)

--- a/SS31.Server/packages.config
+++ b/SS31.Server/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
Updates MonoGame and Lidgren to latest alpha builds compatible with Mono 4.0. Build passes on Linux and Windows.

Also removes superfluous package refs.